### PR TITLE
Add country select box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@fluent/react": "^0.14.1",
         "axios": "^1.1.3",
         "change-case": "^4.1.2",
+        "country-code-emoji": "^2.3.0",
         "date-fns": "^2.29.3",
         "fluent-ranges": "^1.0.1",
         "gatsby": "^5.0.0",
@@ -6723,6 +6724,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/country-code-emoji": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/country-code-emoji/-/country-code-emoji-2.3.0.tgz",
+      "integrity": "sha512-MqmIWr3aucoU/3XZU44e0sz6izAlErqaUYp9/NFzdnzb9TrwwornyW3ws2da5TSnpTUr2qP2840oJW9oNKXCoQ=="
     },
     "node_modules/create-gatsby": {
       "version": "3.0.0",
@@ -23744,6 +23750,11 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "country-code-emoji": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/country-code-emoji/-/country-code-emoji-2.3.0.tgz",
+      "integrity": "sha512-MqmIWr3aucoU/3XZU44e0sz6izAlErqaUYp9/NFzdnzb9TrwwornyW3ws2da5TSnpTUr2qP2840oJW9oNKXCoQ=="
     },
     "create-gatsby": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@fluent/react": "^0.14.1",
     "axios": "^1.1.3",
     "change-case": "^4.1.2",
+    "country-code-emoji": "^2.3.0",
     "date-fns": "^2.29.3",
     "fluent-ranges": "^1.0.1",
     "gatsby": "^5.0.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+/* eslint-disable max-len */
+
 import StandardRoomImage from '~/images/rooms/standard_room.inline.svg'
 import DeluxeRoomImage from '~/images/rooms/deluxe_room.inline.svg'
 import JuniorSuiteImage from '~/images/rooms/junior_suite.inline.svg'
@@ -12,6 +14,7 @@ export default {
 	eventEndDate: new Date('2023-08-06'),
 	earliestBirthDate: new Date('1901-01-01'),
 	minimumAge: 18,
+	allowedCountries: ['AF', 'AX', 'AL', 'DZ', 'AS', 'AD', 'AO', 'AI', 'AQ', 'AG', 'AR', 'AM', 'AW', 'AU', 'AT', 'AZ', 'BS', 'BH', 'BD', 'BB', 'BY', 'BE', 'BZ', 'BJ', 'BM', 'BT', 'BO', 'BQ', 'BA', 'BW', 'BV', 'BR', 'IO', 'BN', 'BG', 'BF', 'BI', 'CV', 'KH', 'CM', 'CA', 'KY', 'CF', 'TD', 'CL', 'CN', 'CX', 'CC', 'CO', 'KM', 'CG', 'CD', 'CK', 'CR', 'CI', 'HR', 'CU', 'CW', 'CY', 'CZ', 'DK', 'DJ', 'DM', 'DO', 'EC', 'EG', 'SV', 'GQ', 'ER', 'EE', 'SZ', 'ET', 'FK', 'FO', 'FJ', 'FI', 'FR', 'GF', 'PF', 'TF', 'GA', 'GM', 'GE', 'DE', 'GH', 'GI', 'GR', 'GL', 'GD', 'GP', 'GU', 'GT', 'GG', 'GN', 'GW', 'GY', 'HT', 'HM', 'VA', 'HN', 'HK', 'HU', 'IS', 'IN', 'ID', 'IR', 'IQ', 'IE', 'IM', 'IL', 'IT', 'JM', 'JP', 'JE', 'JO', 'KZ', 'KE', 'KI', 'KP', 'KR', 'KW', 'KG', 'LA', 'LV', 'LB', 'LS', 'LR', 'LY', 'LI', 'LT', 'LU', 'MO', 'MG', 'MW', 'MY', 'MV', 'ML', 'MT', 'MH', 'MQ', 'MR', 'MU', 'YT', 'MX', 'FM', 'MD', 'MC', 'MN', 'ME', 'MS', 'MA', 'MZ', 'MM', 'NA', 'NR', 'NP', 'NL', 'NC', 'NZ', 'NI', 'NE', 'NG', 'NU', 'NF', 'MK', 'MP', 'NO', 'OM', 'PK', 'PW', 'PS', 'PA', 'PG', 'PY', 'PE', 'PH', 'PN', 'PL', 'PT', 'PR', 'QA', 'RE', 'RO', 'RU', 'RW', 'BL', 'SH', 'KN', 'LC', 'MF', 'PM', 'VC', 'WS', 'SM', 'ST', 'SA', 'SN', 'RS', 'SC', 'SL', 'SG', 'SX', 'SK', 'SI', 'SB', 'SO', 'ZA', 'GS', 'SS', 'ES', 'LK', 'SD', 'SR', 'SJ', 'SE', 'CH', 'SY', 'TW', 'TJ', 'TZ', 'TH', 'TL', 'TG', 'TK', 'TO', 'TT', 'TN', 'TR', 'TM', 'TC', 'TV', 'UG', 'UA', 'AE', 'GB', 'US', 'UM', 'UY', 'UZ', 'VU', 'VE', 'VN', 'VG', 'VI', 'WF', 'EH', 'YE', 'ZM', 'ZW', 'XK'],
 	stagePassPrice: 5,
 	tshirtPrice: 20,
 	tshirtSizes: ['S', 'M', 'L', 'XL', 'XXL'],

--- a/src/localizations/de.ftl
+++ b/src/localizations/de.ftl
@@ -1,1 +1,252 @@
-hello = Hallo Welt!
+country-name = { $countryCode ->
+  [AF] Afghanistan
+  [EG] Ägypten
+  [AX] Åland
+  [AL] Albanien
+  [DZ] Algerien
+  [AS] Amerikanisch-Samoa
+  [VI] Amerikanische Jungferninseln
+  [AD] Andorra
+  [AO] Angola
+  [AI] Anguilla
+  [AQ] Antarktis
+  [AG] Antigua und Barbuda
+  [GQ] Äquatorialguinea
+  [AR] Argentinien
+  [AM] Armenien
+  [AW] Aruba
+  [AZ] Aserbaidschan
+  [ET] Äthiopien
+  [AU] Australien
+  [BS] Bahamas
+  [BH] Bahrain
+  [BD] Bangladesch
+  [BB] Barbados
+  [BY] Belarus
+  [BE] Belgien
+  [BZ] Belize
+  [BJ] Benin
+  [BM] Bermuda
+  [BT] Bhutan
+  [BO] Bolivien
+  [BQ] Bonaire
+  [BA] Bosnien und Herzegowina
+  [BW] Botswana
+  [BV] Bouvetinsel
+  [BR] Brasilien
+  [VG] Britische Jungferninseln
+  [IO] Britisches Territorium im Indischen Ozean
+  [BN] Brunei Darussalam
+  [BG] Bulgarien
+  [BF] Burkina Faso
+  [BI] Burundi
+  [CL] Chile
+  [CN] China
+  [CK] Cookinseln
+  [CR] Costa Rica
+  [CI] Elfenbeinküste
+  [CW] Curaçao
+  [DK] Dänemark
+ *[DE] Deutschland
+  [DM] Dominica
+  [DO] Dominikanische Republik
+  [DJ] Dschibuti
+  [EC] Ecuador
+  [SV] El Salvador
+  [ER] Eritrea
+  [EE] Estland
+  [FK] Falklandinseln
+  [FO] Färöer
+  [FJ] Fidschi
+  [FI] Finnland
+  [FR] Frankreich
+  [GF] Französisch-Guayana
+  [PF] Französisch-Polynesien
+  [TF] Französische Süd- und Antarktisgebiete
+  [GA] Gabun
+  [GM] Gambia
+  [GE] Georgien
+  [GH] Ghana
+  [GI] Gibraltar
+  [GD] Grenada
+  [GR] Griechenland
+  [GL] Grönland
+  [GP] Guadeloupe
+  [GU] Guam
+  [GT] Guatemala
+  [GG] Guernsey
+  [GN] Guinea
+  [GW] Guinea-Bissau
+  [GY] Guyana
+  [HT] Haiti
+  [HM] Heard und McDonaldinseln
+  [HN] Honduras
+  [HK] Hongkong
+  [IN] Indien
+  [ID] Indonesien
+  [IM] Insel Man
+  [IQ] Irak
+  [IR] Iran
+  [IE] Irland
+  [IS] Island
+  [IL] Israel
+  [IT] Italien
+  [JM] Jamaika
+  [JP] Japan
+  [YE] Jemen
+  [JE] Jersey
+  [JO] Jordanien
+  [KY] Kaimaninseln
+  [KH] Kambodscha
+  [CM] Kamerun
+  [CA] Kanada
+  [CV] Kap Verde
+  [KZ] Kasachstan
+  [QA] Katar
+  [KE] Kenia
+  [KG] Kirgisistan
+  [KI] Kiribati
+  [CC] Kokosinseln
+  [CO] Kolumbien
+  [KM] Komoren
+  [CD] Kongo
+  [KP] Nordkorea
+  [KR] Südkorea
+  [HR] Kroatien
+  [CU] Kuba
+  [KW] Kuwait
+  [LA] Laos
+  [LS] Lesotho
+  [LV] Lettland
+  [LB] Libanon
+  [LR] Liberia
+  [LY] Libyen
+  [LI] Liechtenstein
+  [LT] Litauen
+  [LU] Luxemburg
+  [MO] Macao
+  [MG] Madagaskar
+  [MW] Malawi
+  [MY] Malaysia
+  [MV] Malediven
+  [ML] Mali
+  [MT] Malta
+  [MA] Marokko
+  [MH] Marshallinseln
+  [MQ] Martinique
+  [MR] Mauretanien
+  [MU] Mauritius
+  [YT] Mayotte
+  [MX] Mexiko
+  [FM] Mikronesien
+  [MD] Moldawien
+  [MC] Monaco
+  [MN] Mongolei
+  [ME] Montenegro
+  [MS] Montserrat
+  [MZ] Mosambik
+  [MM] Myanmar
+  [NA] Namibia
+  [NR] Nauru
+  [NP] Nepal
+  [NC] Neukaledonien
+  [NZ] Neuseeland
+  [NI] Nicaragua
+  [NL] Niederlande
+  [NE] Niger
+  [NG] Nigeria
+  [NU] Niue
+  [MK] Nordmazedonien
+  [MP] Nördliche Marianen
+  [NF] Norfolkinsel
+  [NO] Norwegen
+  [OM] Oman
+  [AT] Österreich
+  [TL] Osttimor
+  [PK] Pakistan
+  [PS] Staat Palästina
+  [PW] Palau
+  [PA] Panama
+  [PG] Papua-Neuguinea
+  [PY] Paraguay
+  [PE] Peru
+  [PH] Philippinen
+  [PN] Pitcairninseln
+  [PL] Polen
+  [PT] Portugal
+  [PR] Puerto Rico
+  [TW] Taiwan
+  [CG] Republik Kongo
+  [RE] Réunion
+  [RW] Ruanda
+  [RO] Rumänien
+  [RU] Russische Föderation
+  [BL] Saint-Barthélemy
+  [MF] Saint-Martin
+  [SB] Salomonen
+  [ZM] Sambia
+  [WS] Samoa
+  [SM] San Marino
+  [ST] São Tomé und Príncipe
+  [SA] Saudi-Arabien
+  [SE] Schweden
+  [CH] Schweiz
+  [SN] Senegal
+  [RS] Serbien
+  [SC] Seychellen
+  [SL] Sierra Leone
+  [ZW] Simbabwe
+  [SG] Singapur
+  [SX] Sint Maarten
+  [SK] Slowakei
+  [SI] Slowenien
+  [SO] Somalia
+  [ES] Spanien
+  [LK] Sri Lanka
+  [SH] St. Helena
+  [KN] St. Kitts und Nevis
+  [LC] St. Lucia
+  [PM] Saint-Pierre und Miquelon
+  [VC] St. Vincent und die Grenadinen
+  [ZA] Südafrika
+  [SD] Sudan
+  [GS] Südgeorgien und die Südlichen Sandwichinseln
+  [SS] Südsudan
+  [SR] Suriname
+  [SJ] Svalbard und Jan Mayen
+  [SZ] Eswatini
+  [SY] Syrien, Arabische Republik
+  [TJ] Tadschikistan
+  [TZ] Tansania, Vereinigte Republik
+  [TH] Thailand
+  [TG] Togo
+  [TK] Tokelau
+  [TO] Tonga
+  [TT] Trinidad und Tobago
+  [TD] Tschad
+  [CZ] Tschechische Republik
+  [TN] Tunesien
+  [TR] Türkei
+  [TM] Turkmenistan
+  [TC] Turks- und Caicosinseln
+  [TV] Tuvalu
+  [UG] Uganda
+  [UA] Ukraine
+  [HU] Ungarn
+  [UM] United States Minor Outlying Islands
+  [UY] Uruguay
+  [UZ] Usbekistan
+  [VU] Vanuatu
+  [VA] Vatikanstadt
+  [VE] Venezuela
+  [AE] Vereinigte Arabische Emirate
+  [US] Vereinigte Staaten von Amerika
+  [GB] Vereinigtes Königreich
+  [VN] Vietnam
+  [WF] Wallis und Futuna
+  [CX] Weihnachtsinsel
+  [EH] Westsahara
+  [CF] Zentralafrikanische Republik
+  [CY] Zypern
+  [XK] Kosovo
+}

--- a/src/localizations/en.ftl
+++ b/src/localizations/en.ftl
@@ -458,3 +458,256 @@ tshirt-size = { $size ->
   [XL]  X-Large
   [XXL] XX-Large
 }
+
+country-name = { $countryCode ->
+  [AF] Afghanistan
+  [AL] Albania
+  [DZ] Algeria
+  [AS] American Samoa
+  [AD] Andorra
+  [AO] Angola
+  [AI] Anguilla
+  [AQ] Antarctica
+  [AG] Antigua and Barbuda
+  [AR] Argentina
+  [AM] Armenia
+  [AW] Aruba
+  [AU] Australia
+  [AT] Austria
+  [AZ] Azerbaijan
+  [BS] Bahamas
+  [BH] Bahrain
+  [BD] Bangladesh
+  [BB] Barbados
+  [BY] Belarus
+  [BE] Belgium
+  [BZ] Belize
+  [BJ] Benin
+  [BM] Bermuda
+  [BT] Bhutan
+  [BO] Bolivia
+  [BA] Bosnia and Herzegovina
+  [BW] Botswana
+  [BV] Bouvet Island
+  [BR] Brazil
+  [IO] British Indian Ocean Territory
+  [BN] Brunei Darussalam
+  [BG] Bulgaria
+  [BF] Burkina Faso
+  [BI] Burundi
+  [KH] Cambodia
+  [CM] Cameroon
+  [CA] Canada
+  [CV] Cape Verde
+  [KY] Cayman Islands
+  [CF] Central African Republic
+  [TD] Chad
+  [CL] Chile
+  [CN] People's Republic of China
+  [CX] Christmas Island
+  [CC] Cocos (Keeling) Islands
+  [CO] Colombia
+  [KM] Comoros
+  [CG] Republic of the Congo
+  [CD] Democratic Republic of the Congo
+  [CK] Cook Islands
+  [CR] Costa Rica
+  [CI] Cote D'Ivoire
+  [HR] Croatia
+  [CU] Cuba
+  [CY] Cyprus
+  [CZ] Czech Republic
+  [DK] Denmark
+  [DJ] Djibouti
+  [DM] Dominica
+  [DO] Dominican Republic
+  [EC] Ecuador
+  [EG] Egypt
+  [SV] El Salvador
+  [GQ] Equatorial Guinea
+  [ER] Eritrea
+  [EE] Estonia
+  [ET] Ethiopia
+  [FK] Falkland Islands (Malvinas)
+  [FO] Faroe Islands
+  [FJ] Fiji
+  [FI] Finland
+  [FR] France
+  [GF] French Guiana
+  [PF] French Polynesia
+  [TF] French Southern Territories
+  [GA] Gabon
+  [GM] Republic of The Gambia
+  [GE] Georgia
+ *[DE] Germany
+  [GH] Ghana
+  [GI] Gibraltar
+  [GR] Greece
+  [GL] Greenland
+  [GD] Grenada
+  [GP] Guadeloupe
+  [GU] Guam
+  [GT] Guatemala
+  [GN] Guinea
+  [GW] Guinea-Bissau
+  [GY] Guyana
+  [HT] Haiti
+  [HM] Heard Island and McDonald Islands
+  [VA] Holy See (Vatican City State)
+  [HN] Honduras
+  [HK] Hong Kong
+  [HU] Hungary
+  [IS] Iceland
+  [IN] India
+  [ID] Indonesia
+  [IR] Islamic Republic of Iran
+  [IQ] Iraq
+  [IE] Ireland
+  [IL] Israel
+  [IT] Italy
+  [JM] Jamaica
+  [JP] Japan
+  [JO] Jordan
+  [KZ] Kazakhstan
+  [KE] Kenya
+  [KI] Kiribati
+  [KP] North Korea
+  [KR] South Korea
+  [KW] Kuwait
+  [KG] Kyrgyzstan
+  [LA] Lao People's Democratic Republic
+  [LV] Latvia
+  [LB] Lebanon
+  [LS] Lesotho
+  [LR] Liberia
+  [LY] Libya
+  [LI] Liechtenstein
+  [LT] Lithuania
+  [LU] Luxembourg
+  [MO] Macao
+  [MG] Madagascar
+  [MW] Malawi
+  [MY] Malaysia
+  [MV] Maldives
+  [ML] Mali
+  [MT] Malta
+  [MH] Marshall Islands
+  [MQ] Martinique
+  [MR] Mauritania
+  [MU] Mauritius
+  [YT] Mayotte
+  [MX] Mexico
+  [FM] Micronesia, Federated States of
+  [MD] Moldova, Republic of
+  [MC] Monaco
+  [MN] Mongolia
+  [MS] Montserrat
+  [MA] Morocco
+  [MZ] Mozambique
+  [MM] Myanmar
+  [NA] Namibia
+  [NR] Nauru
+  [NP] Nepal
+  [NL] Netherlands
+  [NC] New Caledonia
+  [NZ] New Zealand
+  [NI] Nicaragua
+  [NE] Niger
+  [NG] Nigeria
+  [NU] Niue
+  [NF] Norfolk Island
+  [MK] The Republic of North Macedonia
+  [MP] Northern Mariana Islands
+  [NO] Norway
+  [OM] Oman
+  [PK] Pakistan
+  [PW] Palau
+  [PS] State of Palestine
+  [PA] Panama
+  [PG] Papua New Guinea
+  [PY] Paraguay
+  [PE] Peru
+  [PH] Philippines
+  [PN] Pitcairn
+  [PL] Poland
+  [PT] Portugal
+  [PR] Puerto Rico
+  [QA] Qatar
+  [RE] Reunion
+  [RO] Romania
+  [RU] Russian Federation
+  [RW] Rwanda
+  [SH] Saint Helena
+  [KN] Saint Kitts and Nevis
+  [LC] Saint Lucia
+  [PM] Saint Pierre and Miquelon
+  [VC] Saint Vincent and the Grenadines
+  [WS] Samoa
+  [SM] San Marino
+  [ST] Sao Tome and Principe
+  [SA] Saudi Arabia
+  [SN] Senegal
+  [SC] Seychelles
+  [SL] Sierra Leone
+  [SG] Singapore
+  [SK] Slovakia
+  [SI] Slovenia
+  [SB] Solomon Islands
+  [SO] Somalia
+  [ZA] South Africa
+  [GS] South Georgia and the South Sandwich Islands
+  [ES] Spain
+  [LK] Sri Lanka
+  [SD] Sudan
+  [SR] Suriname
+  [SJ] Svalbard and Jan Mayen
+  [SZ] Eswatini
+  [SE] Sweden
+  [CH] Switzerland
+  [SY] Syrian Arab Republic
+  [TW] Taiwan
+  [TJ] Tajikistan
+  [TZ] United Republic of Tanzania
+  [TH] Thailand
+  [TL] Timor-Leste
+  [TG] Togo
+  [TK] Tokelau
+  [TO] Tonga
+  [TT] Trinidad and Tobago
+  [TN] Tunisia
+  [TR] Türkiye
+  [TM] Turkmenistan
+  [TC] Turks and Caicos Islands
+  [TV] Tuvalu
+  [UG] Uganda
+  [UA] Ukraine
+  [AE] United Arab Emirates
+  [GB] United Kingdom
+  [US] United States of America
+  [UM] United States Minor Outlying Islands
+  [UY] Uruguay
+  [UZ] Uzbekistan
+  [VU] Vanuatu
+  [VE] Venezuela
+  [VN] Vietnam
+  [VG] Virgin Islands, British
+  [VI] Virgin Islands, U.S.
+  [WF] Wallis and Futuna
+  [EH] Western Sahara
+  [YE] Yemen
+  [ZM] Zambia
+  [ZW] Zimbabwe
+  [AX] Åland Islands
+  [BQ] Bonaire, Sint Eustatius and Saba
+  [CW] Curaçao
+  [GG] Guernsey
+  [IM] Isle of Man
+  [JE] Jersey
+  [ME] Montenegro
+  [BL] Saint Barthélemy
+  [MF] Saint Martin (French part)
+  [RS] Serbia
+  [SX] Sint Maarten (Dutch part)
+  [SS] South Sudan
+  [XK] Kosovo
+}

--- a/src/state/models/register.ts
+++ b/src/state/models/register.ts
@@ -1,3 +1,4 @@
+import config from '~/config'
 import { ReadonlyDate } from '~/util/readonly-types'
 
 export type TicketType
@@ -25,7 +26,7 @@ export interface ContactInfo {
 	readonly city: string
 	readonly postalCode: string
 	readonly stateOrProvince: string
-	readonly country: string
+	readonly country: (typeof config.allowedCountries)[number]
 }
 
 export interface OptionalInfo {


### PR DESCRIPTION
Fixes #105 

I'm currently doing the labels/localization with an external library, and it works, but I feel like adding this extra library also makes it needlessly complex. There's like an entire extra localization library to manage, a lot of extra complexity in localization.ts and gatsby-ssr.js, there's having to check for a fallback language in contact.tsx, there's having to edit out offensive country names, ...

It felt like a good idea at first to delegate country names to a more 'official' source, but maybe I should just add the country names to our existing localization files. What do you guys think?