### PR TITLE
fix(#220): timeout settings

### DIFF
--- a/httpd-container.conf
+++ b/httpd-container.conf
@@ -86,25 +86,25 @@ CustomLog /dev/stdout json
             Allow from all
         </Proxy>
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/regsys http://regsys-classic:8080 disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/regsys http://regsys-classic:8080 disablereuse=On connectiontimeout=20 timeout=180
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/regsys http://regsys-classic:8080
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/attsrv/ http://attendee-service:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/attsrv/ http://attendee-service:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/attsrv/ http://attendee-service:8080/
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/authsrv/ http://auth-service:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/authsrv/ http://auth-service:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/authsrv/ http://auth-service:8080/
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/cncrdsrv/ http://payment-cncrd-adapter:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/cncrdsrv/ http://payment-cncrd-adapter:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/cncrdsrv/ http://payment-cncrd-adapter:8080/
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/mailsrv/ http://mail-service:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/mailsrv/ http://mail-service:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/mailsrv/ http://mail-service:8080/
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/roomsrv/ http://room-service:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/roomsrv/ http://room-service:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/roomsrv/ http://room-service:8080/
 
-        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/paysrv/ http://payment-service:8080/ disablereuse=On
+        ProxyPass /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/paysrv/ http://payment-service:8080/ disablereuse=On connectiontimeout=20 timeout=60
         ProxyPassReverse /${HTTPD_CONF_PATH_PREFIX_NO_SLASHES}/paysrv/ http://payment-service:8080/
 
         # configuration for reg-frontend


### PR DESCRIPTION
- closes #220 
- introduces (long) timeouts on all proxied requests, so hanging requests eventually recover