### PR TITLE
demonstrate the problems by removing my workarounds

### DIFF
--- a/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
@@ -12,12 +12,6 @@ export type AugmentedAddon = {
 	}
 }[keyof typeof config.addons]
 
-type AddonSelection = {
-	[key: string]: {
-		readonly selected?: boolean
-	}
-}
-
 export interface TicketLevelAddonProps {
 	readonly addon: AugmentedAddon
 	readonly formContext: ReturnType<typeof useFunnelForm<'register-ticket-level'>>
@@ -48,7 +42,7 @@ const TicketLevelAddon = ({ addon, formContext }: TicketLevelAddonProps) => {
 
 					// skip expensive processing if this addon does not have requirements
 					if (requirements.length > 0) {
-						const nonSelectedAddonIds = Object.entries(value.addons as AddonSelection).filter(([, v]) => v.selected === false).map(([k]) => k as string)
+						const nonSelectedAddonIds = Object.entries(value.addons).filter(([, v]) => !v.selected).map(([k]) => k)
 
 						const includedInMissingRequirements = nonSelectedAddonIds.filter(id => requirements.includes(id))
 

--- a/src/state/selectors/register.ts
+++ b/src/state/selectors/register.ts
@@ -24,10 +24,6 @@ export const getPersonalInfo = () => (s: AppState) => isOpen(s.register) ? s.reg
 export const getContactInfo = () => (s: AppState) => isOpen(s.register) ? s.register.registration.registrationInfo.contactInfo : undefined
 export const getOptionalInfo = () => (s: AppState) => isOpen(s.register) ? s.register.registration.registrationInfo.optionalInfo : undefined
 
-type AddonCountOptions = {
-	readonly count?: string
-}
-
 export const getInvoice = createSelector(getTicketType(), getTicketLevel(), getPaidAmount(), getDueAmount(), (ticketType, ticketLevel, paid, due) => {
 	if (ticketLevel === undefined || ticketType === undefined) {
 		return undefined
@@ -35,8 +31,8 @@ export const getInvoice = createSelector(getTicketType(), getTicketLevel(), getP
 
 	const ticketLevelConfig = config.ticketLevels[ticketLevel.level]
 
-	const convertCount = (countOptions: AddonCountOptions): number => {
-		const code = countOptions.count ?? '1'
+	const convertCount = (count: string | undefined): number => {
+		const code = count ?? '1'
 
 		const withoutPrefix = code.replace(/^c/u, '')
 
@@ -61,7 +57,7 @@ export const getInvoice = createSelector(getTicketType(), getTicketLevel(), getP
 		.filter(([, addon]) => addon.selected)
 		.map(([addonId, addon]) => ({
 			id: `register-ticket-addons-${addonId}`,
-			amount: convertCount(addon.options as AddonCountOptions),
+			amount: convertCount(addon.options?.count),
 			unitPrice: config.ticketLevels[ticketLevel.level].includes?.includes(addonId) ?? false ? 0 : config.addons[addonId].price,
 			options: addon.options,
 		}))


### PR DESCRIPTION
This branch contains an extra commit that removes two of my most ugly workarounds.

On the first one (`addon.tsx`), if you inspect value.addons in the debugger, it very much has a field "selected". But somehow the typescript compiler doesn't seem to understand this.

The second one is even more confusing (`register.ts`). The error message of `npm run tsc` is:

```
src/state/selectors/register.ts:60:40 - error TS2339: Property 'count' does not exist on type '{ readonly count: "c1" | "c2" | "c3" | "c4" | "c5" | "c6" | "c8" | "c10" | "c15" | "c20" | "c30" | "c40" | "c50" | "c100"; } | { readonly count: "c1" | "c2" | "c3" | "c4" | "c5" | "c6" | "c8" | "c10" | "c7" | "c9"; } | ... 28 more ... | {}'.
  Property 'count' does not exist on type '{ readonly size: "XS" | "S" | "M" | "L" | "XL" | "XXL" | "m3XL" | "m4XL" | "wXS" | "wS" | "wM" | "wL" | "wXL" | "wXXL" | "w3XL" | "w4XL"; }'.

```

huh? Property 'count' does not exist on type '{ readonly **count:** ...

Yeah, I know it does not exist on ALL possible types, but that's what the ?.count is for, right?