### PR TITLE
make summerboat naming more clear

### DIFF
--- a/src/localizations/de-DE.ftl
+++ b/src/localizations/de-DE.ftl
@@ -87,16 +87,16 @@ invoice-item-definition-register-ticket-addons-dealer-quad =
   .name = Dealers' Den (4 Tische)
 
 invoice-item-definition-register-ticket-addons-boat-cruise =
-  .name = Bootstour
+  .name = Bootsfahrt Sonntag
 
 invoice-item-definition-register-ticket-addons-boat-trip =
-  .name = Bootsfahrt
+  .name = Bootsfahrt Dienstag
 
 invoice-item-definition-register-ticket-addons-boat-vip =
   .name = Boot VIP
 
 invoice-item-definition-register-ticket-addons-boat-benefactor =
-  .name = Bootssponsor
+  .name = Boot Sponsor
 
 invoice-item-definition-register-ticket-addons-artshow-table-half =
   .name = Art Show (halber Tisch)

--- a/src/localizations/en-US.ftl
+++ b/src/localizations/en-US.ftl
@@ -87,10 +87,10 @@ invoice-item-definition-register-ticket-addons-dealer-quad =
   .name = Dealers' Den (4 Tables)
 
 invoice-item-definition-register-ticket-addons-boat-cruise =
-  .name = Boat Cruise
+  .name = Boat Trip Sunday
 
 invoice-item-definition-register-ticket-addons-boat-trip =
-  .name = Boat Trip
+  .name = Boat Trip Tuesday
 
 invoice-item-definition-register-ticket-addons-boat-vip =
   .name = Boat VIP


### PR DESCRIPTION
Attendees were confused which party they booked after checking their EF registration. Adding the weekday which should (hopefully) stay the same over the years should fix this. Until we do multiple trips a day at least, which isn't planned. For now <.<
