### PR TITLE
Issue 243 fixes

### DIFF
--- a/src/components/funnels/funnels/register/steps/ticket/level.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level.tsx
@@ -11,6 +11,7 @@ import { useAppSelector } from '~/hooks/redux'
 import { getTicketType } from '~/state/selectors/register'
 import { createLuxonFluentDateTime } from '~/util/fluent-values'
 import TicketLevelFootnote from '~/components/funnels/funnels/register/steps/ticket/level/footnote'
+import { useEffect } from 'react'
 
 const TicketLevelGrid = styled.section`
 	display: grid;
@@ -47,7 +48,7 @@ type AddonSelection = {
 const TicketLevel = (_: ReadonlyRouteComponentProps) => {
 	const ticketType = useAppSelector(getTicketType())!
 	const formContext = useFunnelForm('register-ticket-level')
-	const { register, handleSubmit } = formContext
+	const { watch, register, setValue, handleSubmit } = formContext
 
 	const nonSelectedAddonIds = Object.entries(formContext.getValues('addons') as AddonSelection).filter(([, v]) => v.selected === false).map(([k]) => k as string)
 
@@ -60,6 +61,37 @@ const TicketLevel = (_: ReadonlyRouteComponentProps) => {
 		} else {
 			return true
 		}
+	}
+
+	// adjust addons that have resetOn.levelChange on level change, even if they are not currently visible
+	// (this code used to be in addon.tsx, but that does not work if the addon is currently invisible due to being unavailable)
+	useEffect(() => {
+		const subscription = watch((value, { name, type }) => {
+			if (name === 'level' && type === 'change') {
+				const levelValue = value.level as Exclude<typeof value.level, undefined>
+
+				if (levelValue !== null) {
+					Object.entries(config.addons)
+						.filter(([, addon]) => addon.resetOn?.levelChange ?? false)
+						.forEach(([id, addon]) => {
+							const isIncluded = config.ticketLevels[levelValue].includes?.includes(id) ?? false
+							const isRequired = config.ticketLevels[levelValue].requires?.includes(id) ?? false
+							const isUnavailable = config.addons[id].unavailableFor?.level?.includes(levelValue) ?? false
+
+							setValue(`addons.${id}.selected`, (isIncluded || isRequired) && !isUnavailable || addon.default)
+						})
+				}
+			}
+		})
+
+		return () => subscription.unsubscribe()
+	}, [watch])
+
+	const unavailableAddonVisible = (id: keyof typeof config.addons) : boolean => {
+		// an unavailable addon is visible if
+		// - it is already selected (previously bought)
+		// - it is included in the selected ticket level (sponsor upgrades still include a tshirt, the level change needs to be disabled separately, see disablePackageEditForStatuses in config)
+		return Boolean(formContext.getValues('addons')[id].selected) || Boolean(config.ticketLevels[formContext.getValues('level') ?? 'standard']?.includes?.includes(id))
 	}
 
 	return <FullWidthRegisterFunnelLayout onNext={handleSubmit} currentStep={1}>
@@ -131,7 +163,7 @@ const TicketLevel = (_: ReadonlyRouteComponentProps) => {
 						.filter(([, addon]) => !(addon.unavailableFor?.type?.includes(ticketType.type) ?? false))
 						.filter(([, addon]) => !(addon.unavailableFor?.level?.includes(formContext.getValues('level')) ?? false))
 						.filter(([, addon]) => requirementsMet(addon.requires as string[] | undefined))
-						.filter(([id, addon]) => addon.unavailable === true ? Boolean(formContext.getValues('addons')[id].selected) : true)
+						.filter(([id, addon]) => addon.unavailable === true ? unavailableAddonVisible(id) : true)
 						.map(([id, addon]) =>
 							// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
 							<TicketLevelAddon key={id} addon={{ id, ...addon } as AugmentedAddon} formContext={formContext}/>,

--- a/src/components/funnels/funnels/register/steps/ticket/level.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level.tsx
@@ -87,10 +87,13 @@ const TicketLevel = (_: ReadonlyRouteComponentProps) => {
 		return () => subscription.unsubscribe()
 	}, [watch])
 
-	const unavailableAddonVisible = (id: keyof typeof config.addons) : boolean => {
+	const unavailableAddonVisible = (id: keyof typeof config.addons): boolean => {
 		// an unavailable addon is visible if
 		// - it is already selected (previously bought)
 		// - it is included in the selected ticket level (sponsor upgrades still include a tshirt, the level change needs to be disabled separately, see disablePackageEditForStatuses in config)
+		//
+		// (the ticket level in the form context CAN be nullish, which even causes an error!)
+		// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
 		return Boolean(formContext.getValues('addons')[id].selected) || Boolean(config.ticketLevels[formContext.getValues('level') ?? 'standard']?.includes?.includes(id))
 	}
 

--- a/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
@@ -27,20 +27,12 @@ export interface TicketLevelAddonProps {
 const TicketLevelAddon = ({ addon, formContext }: TicketLevelAddonProps) => {
 	const isIncluded = (lvl: TicketLevel['level'] | null) => lvl !== null && (config.ticketLevels[lvl].includes?.includes(addon.id) ?? false)
 	const isRequired = (lvl: TicketLevel['level'] | null) => lvl !== null && (config.ticketLevels[lvl].requires?.includes(addon.id) ?? false)
-	const isUnavailable = (lvl: TicketLevel['level'] | null) => lvl !== null && (config.addons[addon.id].unavailableFor?.level?.includes(lvl) ?? false)
-	const resetOnLevelChange = config.addons[addon.id].resetOn?.levelChange ?? false
 
 	const { watch, register, setValue } = formContext
 	const level = watch('level')
 
 	useEffect(() => {
 		const subscription = watch((value, { name, type }) => {
-			if (resetOnLevelChange && name === 'level' && type === 'change') {
-				const levelValue = value.level as Exclude<typeof value.level, undefined>
-
-				setValue(`addons.${addon.id}.selected`, (isIncluded(levelValue) || isRequired(levelValue)) && !isUnavailable(levelValue) || addon.default)
-			}
-
 			if (name) {
 				if (name.startsWith('addons') && type === 'change') {
 					const requirements = (config.addons[addon.id].requires ?? []) as string[]

--- a/src/config.ts
+++ b/src/config.ts
@@ -144,7 +144,7 @@ const configMmc = {
 } as const
 
 const configEf = {
-	version: 8, // increment to prevent loading from local storage (new year, pricing changes, default packages)
+	version: 9, // increment to prevent loading from local storage (new year, pricing changes, default packages)
 	eventName: 'Eurofurence',
 	registrationLaunch: DateTime.fromISO('2025-01-01T20:00:00+02:00'), // set early enough to allow testing
 	registrationExpirationDate: DateTime.fromISO('2025-09-06', { zone: 'Europe/Berlin' }), // currently unused
@@ -224,7 +224,7 @@ const configEf = {
 		},
 		'late': {
 			price: 15,
-			default: false, // don't forget to increment version when changing this
+			default: true, // don't forget to increment version when changing this
 			options: {},
 			unavailableFor: {
 				type: ['day'],


### PR DESCRIPTION
- fixes #243 
  - tshirt needs to toggle when adding sponsor, because it is included, even if tshirts are set to unavailable (yes, this is counterintuitive, but sponsor level changes have a separate toggle)
- add the late fee for June 15 in config (because it is time)