### PR TITLE
fix(#243): fix several bugs

### DIFF
--- a/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level/addons/addon.tsx
@@ -27,6 +27,7 @@ export interface TicketLevelAddonProps {
 const TicketLevelAddon = ({ addon, formContext }: TicketLevelAddonProps) => {
 	const isIncluded = (lvl: TicketLevel['level'] | null) => lvl !== null && (config.ticketLevels[lvl].includes?.includes(addon.id) ?? false)
 	const isRequired = (lvl: TicketLevel['level'] | null) => lvl !== null && (config.ticketLevels[lvl].requires?.includes(addon.id) ?? false)
+	const isUnavailable = config.addons[addon.id].unavailable ?? false
 
 	const { watch, register, setValue } = formContext
 	const level = watch('level')
@@ -59,12 +60,12 @@ const TicketLevelAddon = ({ addon, formContext }: TicketLevelAddonProps) => {
 			label={addon.id}
 			description={addon.id}
 			price={isIncluded(level) ? 0 : addon.price}
-			disabled={isIncluded(level) || isRequired(level) || addon.id === 'stage-pass'}
+			disabled={isIncluded(level) || isRequired(level) || addon.id === 'stage-pass' || isUnavailable}
 			{...register(`addons.${addon.id}.selected`)}
 		>
 			{Object.entries(addon.options).map(([id, option]) =>
 				// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-				<TicketLevelAddonOption key={id} option={{ id, addonId: addon.id, ...option } as AugmentedOption} formContext={formContext}/>,
+				<TicketLevelAddonOption key={id} option={{ id, addonId: addon.id, ...option } as AugmentedOption} formContext={formContext} preventChange={isUnavailable && id === 'count'}/>,
 			)}
 		</TicketLevelAddonControl>
 	</Localized>

--- a/src/components/funnels/funnels/register/steps/ticket/level/addons/options/option.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level/addons/options/option.tsx
@@ -25,12 +25,13 @@ export type ValidOptionPaths = {
 export interface TicketLevelAddonOptionProps {
 	readonly option: AugmentedOption
 	readonly formContext: ReturnType<typeof useFunnelForm<'register-ticket-level'>>
+	readonly preventChange: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const TicketLevelAddonOption = ({ option, formContext }: TicketLevelAddonOptionProps) => {
+const TicketLevelAddonOption = ({ option, formContext, preventChange }: TicketLevelAddonOptionProps) => {
 	switch (option.type) {
-		case 'select': return <TicketLevelSelectAddonOption option={option} formContext={formContext}/>
+		case 'select': return <TicketLevelSelectAddonOption option={option} formContext={formContext} preventChange={preventChange}/>
 		default: return <div>Not implemented!</div>
 	}
 }

--- a/src/components/funnels/funnels/register/steps/ticket/level/addons/options/select.tsx
+++ b/src/components/funnels/funnels/register/steps/ticket/level/addons/options/select.tsx
@@ -8,6 +8,7 @@ export interface TicketLevelSelectAddonOptionProps {
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
 	readonly option: AugmentedOption<'select'>
 	readonly formContext: ReturnType<typeof useFunnelForm<'register-ticket-level'>>
+	readonly preventChange: boolean
 }
 
 type AddonErrorOptions = {
@@ -20,7 +21,7 @@ type AddonErrorOptions = {
 }
 
 // eslint-disable-next-line @typescript-eslint/prefer-readonly-parameter-types
-const TicketLevelSelectAddonOption = ({ option, formContext: { control, watch, formState: { errors }, FunnelController } }: TicketLevelSelectAddonOptionProps) => {
+const TicketLevelSelectAddonOption = ({ option, formContext: { control, watch, formState: { errors }, FunnelController }, preventChange }: TicketLevelSelectAddonOptionProps) => {
 	const { l10n } = useLocalization()
 
 	const selected = watch(`addons.${option.addonId}.selected`)
@@ -46,7 +47,7 @@ const TicketLevelSelectAddonOption = ({ option, formContext: { control, watch, f
 					label={option.id}
 					isSearchable={false}
 					options={items}
-					onChange={item => onChange(item?.value)}
+					onChange={item => !preventChange ? onChange(item?.value) : undefined}
 					value={value === null ? null : itemsByValue.get(value)}
 					// both count/size may be missing, doing what eslint suggests leads to tsc compile error
 					// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition

--- a/src/config.ts
+++ b/src/config.ts
@@ -140,7 +140,7 @@ const configMmc = {
 		rules: 'https://www.mephitminicon.de/hausordnung.htm',
 		contact: 'https://help.eurofurence.org/contact',
 	},
-	disablePackageEditForStatuses: ['checked in'],
+	disablePackageEditForStatuses: ['checked-in'],
 } as const
 
 const configEf = {
@@ -480,7 +480,7 @@ const configEf = {
 		rules: 'https://help.eurofurence.org/legal/roc',
 		contact: 'https://help.eurofurence.org/contact',
 	},
-	disablePackageEditForStatuses: ['checked in'],
+	disablePackageEditForStatuses: ['checked-in'],
 } as const
 
 const config = checkConfig(configEf)


### PR DESCRIPTION
- if already bought, need to prevent de-selecting unavailable addons
- need to disable count change (but NOT size change) for unavailable addons
- the status is called 'checked-in' in the frontend after all My change caused the status filter for the edit link to not work right